### PR TITLE
fix: correct fix-events script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "fix-events": "ts-node scripts/fix-implicit-event-types.ts"
+    "fix-events": "ts-node script/fix-implicit-event-types.ts"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
## Summary
- correct the fix-events npm script to point at the existing script directory

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_68a77967aa288323a44f36a8a38e0c5a