### PR TITLE
Fix build typing issues for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "fix-events": "ts-node scripts/fix-implicit-event-types.ts"
+    "fix-events": "ts-node script/fix-implicit-event-types.ts"
   },
   "dependencies": {
     "axios": "^0.21.1",
@@ -20,7 +20,8 @@
   "devDependencies": {
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "ts-node": "^10.9.1"
   },
   "keywords": [
     "IELTS",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import Message from './Message';
+import React, { useState } from 'react';
+import Message from './components/Message';
+
+interface ChatMessage {
+  content: string;
+  sender: string;
+}
 
 const Chat = () => {
-  const [messages, setMessages] = useState([]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
 
   // Type the event as a form submit event to satisfy noImplicitAny (TS7006)

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,11 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Message from './Message';
 
+interface ChatMessage {
+    content: string;
+    sender: string;
+}
+
 const Chat = () => {
-    const [messages, setMessages] = useState([]);
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [input, setInput] = useState('');
 
-    const sendMessage = (e) => {
+    const sendMessage = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (input.trim()) {
             const newMessage = { content: input, sender: 'user' };

--- a/src/components/VoiceInput.tsx
+++ b/src/components/VoiceInput.tsx
@@ -1,16 +1,18 @@
 import React, { Component } from 'react';
 
+const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+
 class VoiceInput extends Component {
     state = {
         isListening: false,
         transcript: ''
     };
 
-    recognition = new (window.SpeechRecognition || window.webkitSpeechRecognition)();
+    recognition = new SpeechRecognition();
 
     componentDidMount() {
         this.recognition.interimResults = true;
-        this.recognition.onresult = (event) => {
+        this.recognition.onresult = (event: any) => {
             const transcript = event.results[event.resultIndex][0].transcript;
             this.setState({ transcript });
         };

--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -3,15 +3,16 @@ import { useEffect, useState } from 'react';
 const useVoice = () => {
     const [transcript, setTranscript] = useState('');
     const [isListening, setIsListening] = useState(false);
-    const recognition = new (window.SpeechRecognition || window.webkitSpeechRecognition)();
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    const recognition = new SpeechRecognition();
 
     useEffect(() => {
         recognition.interimResults = true;
 
-        recognition.onresult = (event) => {
+        recognition.onresult = (event: any) => {
             const currentTranscript = Array.from(event.results)
-                .map(result => result[0])
-                .map(result => result.transcript)
+                .map((result: any) => result[0])
+                .map((result: any) => result.transcript)
                 .join('');
             setTranscript(currentTranscript);
         };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const container = document.getElementById("root") as HTMLElement;
+const root = ReactDOM.createRoot(container);
 root.render(
   <React.StrictMode>
     <App />

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const API_URL = 'https://api.example.com'; // Replace with your actual API endpoint
 
-export const sendMessageToAI = async (message) => {
+export const sendMessageToAI = async (message: string) => {
     try {
         const response = await axios.post(`${API_URL}/send`, { message });
         return response.data;
@@ -12,7 +12,7 @@ export const sendMessageToAI = async (message) => {
     }
 };
 
-export const uploadPhoto = async (formData) => {
+export const uploadPhoto = async (formData: FormData) => {
     try {
         const response = await axios.post(`${API_URL}/upload`, formData, {
             headers: {


### PR DESCRIPTION
## Summary
- fix Message import path and add ChatMessage types
- handle browser speech recognition types and events
- add api and index typings and ts-node script
- ignore build and node_modules

## Testing
- `npm test`
- `npm run build`
- `npm run fix-events` *(fails: ts-node: not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a77ffbf41483238e3fddddce1c2e92