### PR TITLE
chore: add explicit types to api utilities

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const API_URL = 'https://api.example.com'; // Replace with your actual API endpoint
 
-export const sendMessageToAI = async (message) => {
+export const sendMessageToAI = async (message: string): Promise<any> => {
     try {
         const response = await axios.post(`${API_URL}/send`, { message });
         return response.data;
@@ -12,7 +12,7 @@ export const sendMessageToAI = async (message) => {
     }
 };
 
-export const uploadPhoto = async (formData) => {
+export const uploadPhoto = async (formData: FormData): Promise<any> => {
     try {
         const response = await axios.post(`${API_URL}/upload`, formData, {
             headers: {


### PR DESCRIPTION
## Summary
- add TypeScript parameter and return types to API helper functions

## Testing
- `CI=true npm test -- --passWithNoTests --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68a7982e2fe88323b00ecb6cfa1d1b3a