### PR TITLE
Remove manual script tag from HTML entrypoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,5 @@
 </head>
 <body>
     <div id="root"></div>
-    <script src="bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove manual `bundle.js` reference from `public/index.html` so CRA injects scripts automatically

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build` *(fails: Module not found: Can't resolve './Message' in '/workspace/ielts-ai-webpage/src')*

------
https://chatgpt.com/codex/tasks/task_b_68a7982dbc208323b9aa3f03e946ba2a