### PR TITLE
Type sendMessage and clean React import

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Message from './Message';
 
 const Chat = () => {
     const [messages, setMessages] = useState([]);
     const [input, setInput] = useState('');
 
-    const sendMessage = (e) => {
+    const sendMessage = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (input.trim()) {
             const newMessage = { content: input, sender: 'user' };


### PR DESCRIPTION
## Summary
- type Chat's form submit handler as `React.FormEvent<HTMLFormElement>`
- remove unused `useEffect` from React import

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm test -- --watchAll=false` *(fails: sh: 1: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a7982bfc088323954d1d5818c669ec